### PR TITLE
docs: better headings

### DIFF
--- a/.markdown-link-check.json
+++ b/.markdown-link-check.json
@@ -5,9 +5,6 @@
         },
         {
             "pattern": "^#"
-        },
-        {
-            "pattern": "^https://stdlib-examples.readthedocs.io"
         }
     ]
 }

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,8 +1,8 @@
-# Safe-DS Stdlib Examples
+# Safe-DS Python Library - Examples
 
 [![PyPI](https://img.shields.io/pypi/v/safe-ds-examples)](https://pypi.org/project/safe-ds-examples/)
 [![Main](https://github.com/Safe-DS/Stdlib-Examples/actions/workflows/main.yml/badge.svg)](https://github.com/Safe-DS/Stdlib-Examples/actions/workflows/main.yml)
 [![codecov](https://codecov.io/gh/Safe-DS/Stdlib-Examples/branch/main/graph/badge.svg?token=X5CU9V952H)](https://codecov.io/gh/Safe-DS/Stdlib-Examples)
 [![Documentation Status](https://readthedocs.org/projects/stdlib-examples/badge/?version=latest)](https://stdlib-examples.readthedocs.io/en/latest/?badge=latest)
 
-Ready-to-use examples for the [Safe-DS Stdlib](https://github.com/Safe-DS/Stdlib).
+Ready-to-use examples for the [Safe-DS Python Library](https://github.com/Safe-DS/Stdlib).

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,4 +1,4 @@
-site_name: Safe-DS Stdlib Examples
+site_name: Safe-DS Python Library - Examples
 repo_url: https://github.com/Safe-DS/Stdlib-Examples
 repo_name: Safe-DS/Stdlib-Examples
 

--- a/src/README.md
+++ b/src/README.md
@@ -1,8 +1,8 @@
-# Safe-DS Stdlib Examples
+# Safe-DS Python Library - Examples
 
 [![PyPI](https://img.shields.io/pypi/v/safe-ds-examples)](https://pypi.org/project/safe-ds-examples/)
 [![Main](https://github.com/Safe-DS/Stdlib-Examples/actions/workflows/main.yml/badge.svg)](https://github.com/Safe-DS/Stdlib-Examples/actions/workflows/main.yml)
 [![codecov](https://codecov.io/gh/Safe-DS/Stdlib-Examples/branch/main/graph/badge.svg?token=X5CU9V952H)](https://codecov.io/gh/Safe-DS/Stdlib-Examples)
 [![Documentation Status](https://readthedocs.org/projects/stdlib-examples/badge/?version=latest)](https://stdlib-examples.readthedocs.io/en/latest/?badge=latest)
 
-Ready-to-use examples for the [Safe-DS Stdlib](https://github.com/Safe-DS/Stdlib).
+Ready-to-use examples for the [Safe-DS Python Library](https://github.com/Safe-DS/Stdlib).


### PR DESCRIPTION
### Summary of Changes

The term "stdlib" makes sense from the perspective of the entire project. For someone who just wants to use the Python components, however, we should instead talk about the "Safe-DS Python Library".