### PR TITLE
docs: set log level to error

### DIFF
--- a/docs/examples/disable_warnings.py
+++ b/docs/examples/disable_warnings.py
@@ -1,0 +1,9 @@
+import logging
+import warnings
+
+
+def disable_warnings() -> None:
+    """Disable output of warnings."""
+
+    logging.root.setLevel(logging.ERROR)
+    warnings.filterwarnings("ignore")

--- a/docs/examples/house_sales.ipynb
+++ b/docs/examples/house_sales.ipynb
@@ -8,10 +8,7 @@
     "The dataset contains house sale prices for King County, USA between May 2014 and May 2015. It is well suited to practice regression techniques."
    ],
    "metadata": {
-    "collapsed": false,
-    "pycharm": {
-     "name": "#%% md\n"
-    }
+    "collapsed": false
    }
   },
   {
@@ -20,10 +17,7 @@
     "## Column descriptions"
    ],
    "metadata": {
-    "collapsed": false,
-    "pycharm": {
-     "name": "#%% md\n"
-    }
+    "collapsed": false
    }
   },
   {
@@ -31,8 +25,9 @@
    "execution_count": null,
    "outputs": [],
    "source": [
-    "import warnings\n",
-    "warnings.filterwarnings(\"ignore\")\n",
+    "from disable_warnings import disable_warnings\n",
+    "\n",
+    "disable_warnings()\n",
     "\n",
     "from safeds_examples.tabular import describe_house_sales_columns\n",
     "from display_column_description import display_column_descriptions\n",
@@ -41,10 +36,7 @@
     "display_column_descriptions(house_sales_description)"
    ],
    "metadata": {
-    "collapsed": false,
-    "pycharm": {
-     "name": "#%%\n"
-    }
+    "collapsed": false
    }
   },
   {
@@ -53,10 +45,7 @@
     "## Sample"
    ],
    "metadata": {
-    "collapsed": false,
-    "pycharm": {
-     "name": "#%% md\n"
-    }
+    "collapsed": false
    }
   },
   {
@@ -70,10 +59,7 @@
     "house_sales.slice(end=10)"
    ],
    "metadata": {
-    "collapsed": false,
-    "pycharm": {
-     "name": "#%%\n"
-    }
+    "collapsed": false
    }
   },
   {
@@ -82,10 +68,7 @@
     "## Schema"
    ],
    "metadata": {
-    "collapsed": false,
-    "pycharm": {
-     "name": "#%% md\n"
-    }
+    "collapsed": false
    }
   },
   {
@@ -96,10 +79,7 @@
     "house_sales.schema"
    ],
    "metadata": {
-    "collapsed": false,
-    "pycharm": {
-     "name": "#%%\n"
-    }
+    "collapsed": false
    }
   },
   {
@@ -108,10 +88,7 @@
     "## Statistics"
    ],
    "metadata": {
-    "collapsed": false,
-    "pycharm": {
-     "name": "#%% md\n"
-    }
+    "collapsed": false
    }
   },
   {
@@ -122,10 +99,7 @@
     "house_sales.summary()"
    ],
    "metadata": {
-    "collapsed": false,
-    "pycharm": {
-     "name": "#%%\n"
-    }
+    "collapsed": false
    }
   },
   {
@@ -134,10 +108,7 @@
     "## Correlation heatmap"
    ],
    "metadata": {
-    "collapsed": false,
-    "pycharm": {
-     "name": "#%% md\n"
-    }
+    "collapsed": false
    }
   },
   {
@@ -159,10 +130,7 @@
     "correlation_heatmap(house_sales_correlation)"
    ],
    "metadata": {
-    "collapsed": false,
-    "pycharm": {
-     "name": "#%%\n"
-    }
+    "collapsed": false
    }
   },
   {
@@ -175,10 +143,7 @@
     "Column descriptions are based on [this Kaggle discussion](https://www.kaggle.com/datasets/harlfoxem/housesalesprediction/discussion/207885).\n"
    ],
    "metadata": {
-    "collapsed": false,
-    "pycharm": {
-     "name": "#%% md\n"
-    }
+    "collapsed": false
    }
   }
  ],

--- a/docs/examples/titanic.ipynb
+++ b/docs/examples/titanic.ipynb
@@ -8,10 +8,7 @@
     "The dataset contains information about the passengers of the Titanic and whether they survived the accident. It is well suited to practice classification techniques."
    ],
    "metadata": {
-    "collapsed": false,
-    "pycharm": {
-     "name": "#%% md\n"
-    }
+    "collapsed": false
    }
   },
   {
@@ -20,10 +17,7 @@
     "## Column descriptions"
    ],
    "metadata": {
-    "collapsed": false,
-    "pycharm": {
-     "name": "#%% md\n"
-    }
+    "collapsed": false
    }
   },
   {
@@ -31,8 +25,9 @@
    "execution_count": null,
    "outputs": [],
    "source": [
-    "import warnings\n",
-    "warnings.filterwarnings(\"ignore\")\n",
+    "from disable_warnings import disable_warnings\n",
+    "\n",
+    "disable_warnings()\n",
     "\n",
     "from safeds_examples.tabular import describe_titanic_columns\n",
     "from display_column_description import display_column_descriptions\n",
@@ -41,10 +36,7 @@
     "display_column_descriptions(titanic_description)"
    ],
    "metadata": {
-    "collapsed": false,
-    "pycharm": {
-     "name": "#%%\n"
-    }
+    "collapsed": false
    }
   },
   {
@@ -53,10 +45,7 @@
     "## Sample"
    ],
    "metadata": {
-    "collapsed": false,
-    "pycharm": {
-     "name": "#%% md\n"
-    }
+    "collapsed": false
    }
   },
   {
@@ -70,10 +59,7 @@
     "titanic.slice(end=10)"
    ],
    "metadata": {
-    "collapsed": false,
-    "pycharm": {
-     "name": "#%%\n"
-    }
+    "collapsed": false
    }
   },
   {
@@ -82,10 +68,7 @@
     "## Schema"
    ],
    "metadata": {
-    "collapsed": false,
-    "pycharm": {
-     "name": "#%% md\n"
-    }
+    "collapsed": false
    }
   },
   {
@@ -96,10 +79,7 @@
     "titanic.schema"
    ],
    "metadata": {
-    "collapsed": false,
-    "pycharm": {
-     "name": "#%%\n"
-    }
+    "collapsed": false
    }
   },
   {
@@ -108,10 +88,7 @@
     "## Statistics"
    ],
    "metadata": {
-    "collapsed": false,
-    "pycharm": {
-     "name": "#%% md\n"
-    }
+    "collapsed": false
    }
   },
   {
@@ -122,10 +99,7 @@
     "titanic.summary()"
    ],
    "metadata": {
-    "collapsed": false,
-    "pycharm": {
-     "name": "#%%\n"
-    }
+    "collapsed": false
    }
   },
   {
@@ -134,10 +108,7 @@
     "## Correlation heatmap"
    ],
    "metadata": {
-    "collapsed": false,
-    "pycharm": {
-     "name": "#%% md\n"
-    }
+    "collapsed": false
    }
   },
   {
@@ -154,10 +125,7 @@
     "correlation_heatmap(titanic_correlation)"
    ],
    "metadata": {
-    "collapsed": false,
-    "pycharm": {
-     "name": "#%%\n"
-    }
+    "collapsed": false
    }
   },
   {
@@ -172,10 +140,7 @@
     "> Thomas Cason of UVa has greatly updated and improved the titanic data frame using the Encyclopedia Titanica and created the dataset here. Some duplicate passengers have been dropped, many errors corrected, many missing ages filled in, and new variables created.\n"
    ],
    "metadata": {
-    "collapsed": false,
-    "pycharm": {
-     "name": "#%% md\n"
-    }
+    "collapsed": false
    }
   }
  ],


### PR DESCRIPTION
### Summary of Changes

https://github.com/Safe-DS/Stdlib-Examples/pull/27 didn't fix the issue that the generated docs contained warnings:

![image](https://user-images.githubusercontent.com/2501322/225864712-7d876a6e-bb89-4427-af5b-0bd98d3bc0ad.png)

This PR also sets the log level of the root logger to `ERROR`.