### PR TITLE
docs: exclude `.py` files from built site

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -66,6 +66,9 @@ plugins:
       execute: true
       allow_errors: false
       no_input: true
+  - exclude:
+      glob:
+        - "*.py"
 
 watch:
   - src

--- a/poetry.lock
+++ b/poetry.lock
@@ -1546,6 +1546,20 @@ Markdown = ">=3.3"
 mkdocs = ">=1.1"
 
 [[package]]
+name = "mkdocs-exclude"
+version = "1.0.2"
+description = "A mkdocs plugin that lets you exclude files or trees."
+category = "dev"
+optional = false
+python-versions = "*"
+files = [
+    {file = "mkdocs-exclude-1.0.2.tar.gz", hash = "sha256:ba6fab3c80ddbe3fd31d3e579861fd3124513708271180a5f81846da8c7e2a51"},
+]
+
+[package.dependencies]
+mkdocs = "*"
+
+[[package]]
 name = "mkdocs-gen-files"
 version = "0.4.0"
 description = "MkDocs plugin to programmatically generate documentation pages during the build"
@@ -3261,4 +3275,4 @@ files = [
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10"
-content-hash = "bb0a324eb181a4f7930073a7fe5a9e7b8b87b7e72ec7b9c625ab5f9b613b53f4"
+content-hash = "c76b9e64f08c32fc552f6779a4a35daa320e27443b32bd2c627ecd695a2433d4"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,6 +32,7 @@ mkdocs-literate-nav = "^0.6.0"
 mkdocs-material = "^9.1.2"
 mkdocs-section-index = "^0.3.5"
 mkdocs-jupyter = "^0.23.0"
+mkdocs-exclude = "^1.0.2"
 
 [build-system]
 requires = ["poetry-core"]


### PR DESCRIPTION
### Summary of Changes

Exclude `.py` files from built site since they are only needed to build the site in the first place. Afterwards, they just take up space.
