### PR TITLE
ci: also build with Python 3.11

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -7,10 +7,14 @@ on:
 jobs:
   poetry-with-codecov:
     strategy:
+      fail-fast: false
       matrix:
-        python-version: [ "3.10" ]
+        python-version:
+          - "3.10"
+          - "3.11"
     uses: lars-reimann/.github/.github/workflows/poetry-codecov-reusable.yml@main
     with:
       working-directory: .
       python-version: ${{ matrix.python-version }}
       module-name: safeds_examples
+      coverage: ${{ matrix.python-version == '3.10' }}

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -11,10 +11,14 @@ concurrency:
 jobs:
   poetry-with-codecov:
     strategy:
+      fail-fast: false
       matrix:
-        python-version: [ "3.10" ]
+        python-version:
+          - "3.10"
+          - "3.11"
     uses: lars-reimann/.github/.github/workflows/poetry-codecov-reusable.yml@main
     with:
       working-directory: .
       python-version: ${{ matrix.python-version }}
       module-name: safeds_examples
+      coverage: ${{ matrix.python-version == '3.10' }}


### PR DESCRIPTION
### Summary of Changes

We support Python 3.11, so we should also ensure the library can be used with it.