### PR TITLE
docs: fail on warnings

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -3,6 +3,7 @@ repo_url: https://github.com/Safe-DS/Stdlib-Examples
 repo_name: Safe-DS/Stdlib-Examples
 edit_uri: edit/main/docs/
 site_url: !ENV READTHEDOCS_CANONICAL_URL
+strict: true
 
 nav:
   - Home:


### PR DESCRIPTION
### Summary of Changes

* Enable strict mode of `mkdocs` to fail on warnings
